### PR TITLE
fix(styles): align marquee track to flex-start to prevent clipping

### DIFF
--- a/site/static/styles/main.css
+++ b/site/static/styles/main.css
@@ -569,6 +569,7 @@ img {
     display: flex;
     gap: 0.9rem;
     align-items: flex-end;
+    justify-content: flex-start;
     /* no CSS transform-based animation anymore; JS handles auto-scroll */
 }
 


### PR DESCRIPTION
Changing .marquee-track to justify-content: flex start so overflowing cards start from the left edge instead of getting pushed off-screen 
The gallery has too many cards to fit on screen so centering it hides the first few cards off to the left
Tested locally and works fine



| Before | After |
| :---: | :---: |
| <img src="https://github.com/user-attachments/assets/bce02e6c-9b82-4415-87f5-7597d089709c" alt="Before - Marquee clipped" width="450" /> | <img src="https://github.com/user-attachments/assets/1ade663a-210e-460d-878a-0414d1bbc9e7" alt="After - Properly aligned" width="450" /> |


